### PR TITLE
Update Cargo.lock to fix proc-macro2 build failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,14 +10,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc-stub"
 version = "0.1.0"
 dependencies = [
- "wasm-bindgen 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)",
+ "wasm-bindgen 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)",
 ]
 
 [[package]]
@@ -25,7 +25,7 @@ name = "libsodium-sys"
 version = "0.0.16"
 source = "git+https://github.com/alexcrichton/sodiumoxide?branch=wasm32#25ef676224fec702c5664ff37e489f406b45d43e"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -44,45 +44,35 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.43"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.43"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -90,18 +80,18 @@ name = "sodiumoxide"
 version = "0.0.16"
 source = "git+https://github.com/alexcrichton/sodiumoxide?branch=wasm32#25ef676224fec702c5664ff37e489f406b45d43e"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libsodium-sys 0.0.16 (git+https://github.com/alexcrichton/sodiumoxide?branch=wasm32)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -112,44 +102,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.8"
-source = "git+https://github.com/alexcrichton/wasm-bindgen#6c28e5f273f276b45e71c5ffcd094e4ee5d739d0"
+version = "0.2.10"
+source = "git+https://github.com/alexcrichton/wasm-bindgen#dd76707ea1a3e9d4d0738e198b4f2fc9d93a8126"
 dependencies = [
- "wasm-bindgen-macro 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)",
+ "wasm-bindgen-macro 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.8"
-source = "git+https://github.com/alexcrichton/wasm-bindgen#6c28e5f273f276b45e71c5ffcd094e4ee5d739d0"
+version = "0.2.10"
+source = "git+https://github.com/alexcrichton/wasm-bindgen#dd76707ea1a3e9d4d0738e198b4f2fc9d93a8126"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-shared 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)",
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-shared 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.8"
-source = "git+https://github.com/alexcrichton/wasm-bindgen#6c28e5f273f276b45e71c5ffcd094e4ee5d739d0"
+version = "0.2.10"
+source = "git+https://github.com/alexcrichton/wasm-bindgen#dd76707ea1a3e9d4d0738e198b4f2fc9d93a8126"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-bindgen-backend 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)",
- "wasm-bindgen-shared 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)",
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-bindgen-backend 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.8"
-source = "git+https://github.com/alexcrichton/wasm-bindgen#6c28e5f273f276b45e71c5ffcd094e4ee5d739d0"
+version = "0.2.10"
+source = "git+https://github.com/alexcrichton/wasm-bindgen#dd76707ea1a3e9d4d0738e198b4f2fc9d93a8126"
 dependencies = [
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -158,25 +146,24 @@ version = "0.1.0"
 dependencies = [
  "libc-stub 0.1.0",
  "sodiumoxide 0.0.16 (git+https://github.com/alexcrichton/sodiumoxide?branch=wasm32)",
- "wasm-bindgen 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)",
+ "wasm-bindgen 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)",
 ]
 
 [metadata]
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
 "checksum libsodium-sys 0.0.16 (git+https://github.com/alexcrichton/sodiumoxide?branch=wasm32)" = "<none>"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
-"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
-"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
-"checksum serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "0c855d888276f20d140223bd06515e5bf1647fd6d02593cb5792466d9a8ec2d0"
-"checksum serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "aa113e5fc4b008a626ba2bbd41330b56c9987d667f79f7b243e5a2d03d91ed1c"
-"checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
-"checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
+"checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
+"checksum quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e53eeda07ddbd8b057dde66d9beded11d0dfda13f0db0769e6b71d6bcf2074e"
+"checksum serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "2a4d976362a13caad61c38cf841401d2d4d480496a9391c3842c288b01f9de95"
+"checksum serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "94bb618afe46430c6b089e9b111dc5b2fcd3e26a268da0993f6d16bea51c6021"
+"checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
 "checksum sodiumoxide 0.0.16 (git+https://github.com/alexcrichton/sodiumoxide?branch=wasm32)" = "<none>"
-"checksum syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90d5efaad92a0f96c629ae16302cc9591915930fd49ff0dcc6b4cde146782397"
+"checksum syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d991a9e7c33123925e511baab68f7ec25c3795962fe326a2395e5a42a614f0"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-"checksum wasm-bindgen 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"
-"checksum wasm-bindgen-backend 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"
-"checksum wasm-bindgen-macro 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"
-"checksum wasm-bindgen-shared 0.2.8 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"
+"checksum wasm-bindgen 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"
+"checksum wasm-bindgen-backend 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"
+"checksum wasm-bindgen-macro 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"
+"checksum wasm-bindgen-shared 0.2.10 (git+https://github.com/alexcrichton/wasm-bindgen)" = "<none>"


### PR DESCRIPTION
After updating to Rust 1.28 nightly the build started failing on my system:
```bash
< ... previous Docker output ... >
+ docker run --user 1000:1000 --volume /home/sl/Code/Infuse/wasm-sodium:/c:ro --volume /home/sl/Code/Infuse/wasm-sodium/target:/c/target --volume /home/sl/.cargo:/cargo --workdir /c --volume /home/sl/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu:/rust:ro --interactive --tty --rm wasm-sodium-test cargo build --target wasm32-unknown-unknown --release
   Compiling unicode-xid v0.1.0
   Compiling wasm-bindgen-shared v0.2.8 (https://github.com/alexcrichton/wasm-bindgen#6c28e5f2)
   Compiling itoa v0.4.1
   Compiling serde v1.0.43
   Compiling dtoa v0.4.2
   Compiling pkg-config v0.3.11
   Compiling libc v0.2.40
   Compiling proc-macro2 v0.3.8
error[E0433]: failed to resolve. Could not find `Op` in `proc_macro`
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.8/src/unstable.rs:131:42
    |
131 |                 let mut op = proc_macro::Op::new(tt.op(), spacing);
    |                                          ^^ Could not find `Op` in `proc_macro`

error[E0433]: failed to resolve. Could not find `Term` in `proc_macro`
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.8/src/unstable.rs:446:59
    |
446 |             Span::Nightly(s) => Term::Nightly(proc_macro::Term::new(string, s)),
    |                                                           ^^^^ Could not find `Term` in `proc_macro`

error[E0412]: cannot find type `Term` in module `proc_macro`
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.8/src/unstable.rs:439:25
    |
439 |     Nightly(proc_macro::Term),
    |                         ^^^^ not found in `proc_macro`
help: possible candidates are found in other modules, you can import them into scope
    |
3   | use Term;
    |
3   | use imp::Term;
    |
3   | use stable::Term;
    |

error[E0412]: cannot find type `Term` in module `proc_macro`
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.8/src/unstable.rs:473:44
    |
473 |     fn unwrap_nightly(self) -> proc_macro::Term {
    |                                            ^^^^ not found in `proc_macro`
help: possible candidates are found in other modules, you can import them into scope
    |
3   | use Term;
    |
3   | use imp::Term;
    |
3   | use stable::Term;
    |

error[E0599]: no variant named `Op` found for type `proc_macro::TokenTree` in the current scope
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.8/src/unstable.rs:228:13
    |
228 |             proc_macro::TokenTree::Op(tt) => {
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variant not found in `proc_macro::TokenTree`

error[E0599]: no variant named `Term` found for type `proc_macro::TokenTree` in the current scope
   --> /cargo/registry/src/github.com-1ecc6299db9ec823/proc-macro2-0.3.8/src/unstable.rs:237:13
    |
237 |             proc_macro::TokenTree::Term(s) => ::Term::_new(Term::Nightly(s)).into(),
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variant not found in `proc_macro::TokenTree`

error: aborting due to 6 previous errors

Some errors occurred: E0412, E0433, E0599.
For more information about an error, try `rustc --explain E0412`.
error: Could not compile `proc-macro2`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```

Updating `Cargo.lock` fixes this.